### PR TITLE
Add functionality for admin list

### DIFF
--- a/apps/kita/app/Http/Controllers/Admin/AdminListController.php
+++ b/apps/kita/app/Http/Controllers/Admin/AdminListController.php
@@ -3,17 +3,38 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Services\Admin\AdminSearchService;
+use Illuminate\Http\Request;
 
 class AdminListController extends Controller
 {
+    /**
+     * @var AdminSearchService
+     */
+    protected $adminSearchService;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param AdminSearchService $adminSearchService
+     * @return void
+     */
+    public function __construct(AdminSearchService $adminSearchService)
+    {
+        $this->adminSearchService = $adminSearchService;
+    }
+
     /**
      * Display a listing of the admin users.
      *
      * @return \Illuminate\View\View
      */
-    public function index()
+    public function index(Request $request)
     {
-        // ビューを返す
-        return view('admin.index');
+        // サービスクラスを使用して管理者ユーザーを取得
+        $adminUsers = $this->adminSearchService->getAdminUsers($request);
+
+        // ビューに結果を渡して表示
+        return view('admin.index', compact('adminUsers'));
     }
 }

--- a/apps/kita/app/Services/Admin/AdminSearchService.php
+++ b/apps/kita/app/Services/Admin/AdminSearchService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\AdminUser;
+use Illuminate\Http\Request;
+
+class AdminSearchService
+{
+    private const PAGINATION_COUNT = 10;
+
+    /**
+     * Get paginated admin users based on search criteria.
+     *
+     * @param Request $request
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getAdminUsers(Request $request)
+    {
+        // クエリビルダーのインスタンス作成
+        $query = AdminUser::query();
+
+        // 特殊文字をエスケープする関数
+        $escapeLike = function ($value) {
+            return '%'.str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value).'%';
+        };
+
+        // 姓で部分一致（where句の追加）
+        if ($request->filled('first_name')) {
+            $query->where('first_name', 'like', $escapeLike($request->input('first_name')));
+        }
+
+        // 名で部分一致（where句の追加）
+        if ($request->filled('last_name')) {
+            $query->where('last_name', 'like', $escapeLike($request->input('last_name')));
+        }
+
+        // メールアドレスで部分一致（where句の追加）
+        if ($request->filled('email')) {
+            $query->where('email', 'like', $escapeLike($request->input('email')));
+        }
+
+        // ここでクエリ発行
+        return $query->orderBy('created_at', 'desc')
+                     ->paginate(self::PAGINATION_COUNT)
+                     ->appends($request->query());
+    }
+}

--- a/apps/kita/app/Services/Helpers/StringHelper.php
+++ b/apps/kita/app/Services/Helpers/StringHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\Helpers;
+
+class StringHelper
+{
+    /**
+     * Escape special characters for use in SQL like queries.
+     *
+     * @param string $value
+     * @return string
+     */
+    // タグ、会員検索でもおそらく使用
+    public static function escapeLike(string $value): string
+    {
+        return '%'.str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $value).'%';
+    }
+}

--- a/apps/kita/resources/views/admin/index.blade.php
+++ b/apps/kita/resources/views/admin/index.blade.php
@@ -1,4 +1,99 @@
 @extends('layouts.admin')
+
 @section('content')
-    <!-- ここに管理者一覧 -->
+    <div class="container-fluid">
+        <div class="row justify-content-center">
+            <div class="col-md-12">
+                <!-- エラーメッセージ -->
+                @include('vendor.alerts.success')
+                @include('vendor.alerts.error')
+
+                <div>
+                    <h1>管理者管理</h1>
+                </div>
+                <!-- 検索 -->
+                <div class="card my-4 overflow-hidden">
+                    <!-- 検索機能 -->
+                    {!! Form::open(['route' => 'admin.users.index', 'method' => 'get']) !!}
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-4">
+                                {!! Form::label('last_name', '姓', ['class' => 'form-label']) !!}
+                                {!! Form::text('last_name', request('last_name'), ['id' => 'last_name', 'class' => 'form-control']) !!}
+                            </div>
+                            <div class="col-md-4">
+                                {!! Form::label('first_name', '名', ['class' => 'form-label']) !!}
+                                {!! Form::text('first_name', request('first_name'), ['id' => 'first_name', 'class' => 'form-control']) !!}
+                            </div>
+                            <div class="col-md-4">
+                                {!! Form::label('email', 'メールアドレス', ['class' => 'form-label']) !!}
+                                {!! Form::text('email', request('email'), ['id' => 'email', 'class' => 'form-control']) !!}
+                            </div>
+                        </div>
+                    </div>
+                    <div style="background-color: #e9ecef;">
+                        <hr class="border-secondary">
+                        <div class="d-flex justify-content-center">
+                            {!! Form::submit('検索', ['class' => 'btn btn-primary px-3 mb-3']) !!}
+                        </div>
+                    </div>
+                    {!! Form::close() !!}
+                </div>
+                <!-- ページネーション -->
+                <div class="d-flex justify-content-start custom-pagination mt-4 mb-0">
+                    {{ $adminUsers->links('vendor.pagination.admin') }}
+                </div>
+                <!-- 会員一覧 -->
+                <div class="card">
+                    <div class="d-flex justify-content-start">
+                        <!-- 後でルート付与 -->
+                        <div class="btn btn-primary px-3 m-4">
+                            新規登録
+                        </div>
+                    </div>
+                    <!-- ここ -->
+                    <!-- 管理者テーブル -->
+                    @if($adminUsers->isEmpty())
+                        <div class="alert alert-warning mx-3" role="alert">
+                            管理者が存在しません
+                        </div>
+                    @else
+                    <div class="table-responsive mx-4">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th class="text-center">ID</th>
+                                    <th class="px-4">名前</th>
+                                    <th class="px-4">メールアドレス</th>
+                                    <th class="text-end">更新日時</th>
+                                    <th class="text-end">登録日時</th>
+                                    <th class="text-nowrap text-center">レコード操作</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($adminUsers as $user)
+                                <tr>
+                                    <td class="text-center">{{ $user->id }}</td>
+                                    <td class="px-4">{{ $user->last_name }} {{ $user->first_name }}</td>
+                                    <td class="px-4">{{ $user->email }}</td>
+                                    <td class="text-end">{{ $user->updated_at->format('Y/m/d H:i') }}</td>
+                                    <td class="text-end">{{ $user->created_at->format('Y/m/d H:i') }}</td>
+                                    <td>
+                                    <div class="d-flex justify-content-center align-items-center">
+                                        <!-- 後でルート付与 -->
+                                        <div class="btn btn-primary px-3 py-1 text-nowrap">
+                                            編集
+                                        </div>
+                                    </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection

--- a/apps/kita/resources/views/layouts/admin.blade.php
+++ b/apps/kita/resources/views/layouts/admin.blade.php
@@ -2,14 +2,25 @@
 <body style="background-color: #e9ecef;">
 <div id="app">
     <nav class="fixed-top navbar border-bottom border-secondary-subtle bg-dark">
-        <div class="row justify-content-center w-100">
-            <div class="d-flex align-items-center justify-content-between">
-                <!-- アプリ名 -->
-                <span class="card-title text-start text-white" style="font-family: 'Poppins', sans-serif;">
-                    <span class="fs-1 fw-bold ms-3">K</span><span class="fs-1">ita</span>
-                </span>
-                <!-- ログアウトボタン -->
-                <div>
+        <div class="container-fluid">
+            <div class="d-flex justify-content-between w-100">
+
+                <!-- 左寄せ -->
+                <div class="d-flex align-items-center">
+                    <!-- アプリ名 -->
+                    <span class="card-title text-start text-white" style="font-family: 'Poppins', sans-serif;">
+                        <span class="fs-1 fw-bold ms-3">K</span><span class="fs-1">ita</span>
+                    </span>
+                    @if (Auth::guard('admin')->check())
+                        <!-- 管理者管理ボタン -->
+                        <a href="{{ route('admin.users.index') }}" class="text-white text-decoration-none ms-5">
+                            管理者管理
+                        </a>
+                    @endif
+                </div>
+
+                <!-- 右寄せ -->
+                <div class="d-flex align-items-center ms-auto">
                     @if (Auth::guard('admin')->check())
                         <form id="logout-form" action="{{ route('admin.logout') }}" method="POST" class="d-inline">
                             @csrf

--- a/apps/kita/resources/views/layouts/admin.blade.php
+++ b/apps/kita/resources/views/layouts/admin.blade.php
@@ -1,41 +1,51 @@
 @include('partials.head')
 <body style="background-color: #e9ecef;">
 <div id="app">
-    <nav class="fixed-top navbar border-bottom border-secondary-subtle bg-dark">
+    <nav class="navbar navbar-expand-md fixed-top navbar-dark bg-dark border-bottom border-secondary-subtle">
         <div class="container-fluid">
-            <div class="d-flex justify-content-between w-100">
+            <!-- アプリ名 -->
+            <span class="card-title text-start text-white" style="font-family: 'Poppins', sans-serif;">
+                <span class="fs-1 fw-bold ms-3">K</span><span class="fs-1">ita</span>
+            </span>
 
-                <!-- 左寄せ -->
-                <div class="d-flex align-items-center">
-                    <!-- アプリ名 -->
-                    <span class="card-title text-start text-white" style="font-family: 'Poppins', sans-serif;">
-                        <span class="fs-1 fw-bold ms-3">K</span><span class="fs-1">ita</span>
-                    </span>
-                    @if (Auth::guard('admin')->check())
-                        <!-- 管理者管理ボタン -->
-                        <a href="{{ route('admin.users.index') }}" class="text-white text-decoration-none ms-5">
-                            管理者管理
-                        </a>
-                    @endif
-                </div>
+            <!-- トグルボタン -->
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleContent" aria-controls="navbarToggleContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
 
-                <!-- 右寄せ -->
-                <div class="d-flex align-items-center ms-auto">
+            <!-- ナビゲーションメニュー -->
+            <div class="collapse navbar-collapse" id="navbarToggleContent">
+                <ul class="navbar-nav me-md-auto mb-2 mb-sm-0">
                     @if (Auth::guard('admin')->check())
-                        <form id="logout-form" action="{{ route('admin.logout') }}" method="POST" class="d-inline">
-                            @csrf
-                            <button type="submit" class="btn btn-outline-light btn-sm">
-                                ログアウト
-                            </button>
-                        </form>
+                        <div class="nav-item d-md-flex text-end ms-5">
+                            <a href="{{ route('admin.users.index') }}" class="nav-link text-white text-nowrap ms-3">
+                                管理者管理
+                            </a>
+                        </div>
+                        <!--ここに会員管理-->
+                        <!--ここにタグ管理-->
                     @endif
-                </div>
+                </ul>
+                <ul class="navbar-nav ms-auto mb-2">
+                    @if (Auth::guard('admin')->check())
+                        <li class="nav-item text-end">
+                            <form id="logout-form" action="{{ route('admin.logout') }}" method="POST" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-light btn-sm">
+                                    ログアウト
+                                </button>
+                            </form>
+                        </li>
+                    @endif
+                </ul>
             </div>
         </div>
     </nav>
+
     <!-- ダミー要素 -->
     <div class="d-sm-none" style="height: 80px;"></div>
     <div class="d-none d-sm-flex" style="height: 110px;"></div>
+
     <main>
         @yield('content')
     </main>

--- a/apps/kita/resources/views/vendor/pagination/admin.blade.php
+++ b/apps/kita/resources/views/vendor/pagination/admin.blade.php
@@ -1,0 +1,54 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Page navigation example" class="d-flex justify-content-center">
+        <ul class="pagination pagination-sm">
+            {{-- 前ページのリンク --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled">
+                    <a class="page-link text-primary border-primary text-nowrap">{!! __('Previous') !!}</a>
+                </li>
+            @else
+                <li class="page-item">
+                    <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="page-link text-primary border-primary hover:text-primary">{!! __('Previous') !!}</a>
+                </li>
+            @endif
+
+            {{-- ページネーションの数字部分を取得 --}}
+            @php
+                $pageRange = 1;
+                $start = max($paginator->currentPage() - $pageRange, 1);
+                $end = min($paginator->currentPage() + $pageRange, $paginator->lastPage());
+
+                if ($paginator->currentPage() <= $pageRange + 1) {
+                    $end = min($pageRange * 2 + 1, $paginator->lastPage());
+                }
+
+                if ($paginator->currentPage() >= $paginator->lastPage() - $pageRange) {
+                    $start = max($paginator->lastPage() - $pageRange * 2, 1);
+                }
+            @endphp
+
+            @for ($page = $start; $page <= $end; $page++)
+                @if ($page == $paginator->currentPage())
+                    <li class="page-item active" aria-current="page">
+                        <a class="page-link bg-primary border-primary text-white">{{ $page }}</a>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a href="{{ $paginator->url($page) }}" class="page-link text-primary border-primary hover:text-primary">{{ $page }}</a>
+                    </li>
+                @endif
+            @endfor
+
+            {{-- 次ページのリンク --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="page-link text-primary border-primary hover:text-primary">{!! __('Next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled">
+                    <a class="page-link text-primary border-primary text-nowrap">{!! __('Next') !!}</a>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -114,8 +114,11 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
     // 管理者ログイン状態で利用可能なルート
     Route::middleware('auth:admin')->group(function () {
-        // 管理者一覧画面の表示
-        Route::get('/admin_users', [AdminListController::class, 'index'])
-            ->name('users.index');
+        // admin/admin_usersのルート
+        Route::prefix('admin_users')->group(function () {
+            // 管理者一覧画面の表示
+            Route::get('/', [AdminListController::class, 'index'])
+                ->name('users.index');
+        });
     });
 });


### PR DESCRIPTION
・機能：管理者一覧、検索
・URL：http://localhost/admin/admin_users （管理者管理ボタン押した時）、 http://localhost/admin/admin_users?last_name={value}&first_name={value}&email={value}  （検索時）
・チケット：https://fullspeed.atlassian.net/browse/CBET-819
・画像：
<img width="1512" alt="スクリーンショット 2024-08-27 14 57 27" src="https://github.com/user-attachments/assets/cf92a9b4-d31d-4db8-9960-d4249af91c46">

※ 会員、タグ、管理者全ての検索一覧の機能に関して、StringHelper.php（エスケープ処理）と admin.blade.php × 2（ページネーションとnavバー）と indは同じファイルを使用してます。
